### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven_ci.yml
+++ b/.github/workflows/maven_ci.yml
@@ -1,5 +1,8 @@
 name: "Call Java CI with Maven"
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Sundsvallskommun/api-service-teams-sender/security/code-scanning/1](https://github.com/Sundsvallskommun/api-service-teams-sender/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow. Since the specific permissions required by the shared workflow are not detailed, we will start with the most restrictive permissions (`contents: read`) and adjust them if additional permissions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
